### PR TITLE
reset currently selected date if initialSelectedDate is updated

### DIFF
--- a/lib/date_picker_widget.dart
+++ b/lib/date_picker_widget.dart
@@ -156,6 +156,16 @@ class _DatePickerState extends State<DatePicker> {
     );
   }
 
+  @override
+  void didUpdateWidget (DatePicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    
+    // if widget is updated and initial selected date is different from before
+    // reset currently selected date
+    if(oldWidget.initialSelectedDate != widget.initialSelectedDate)
+      _currentDate = widget.initialSelectedDate;
+  }
+
   /// Helper function to compare two dates
   /// Returns True if both dates are the same
   bool _compareDate(DateTime date1, DateTime date2) {


### PR DESCRIPTION
I have a case where I need to update the `initialSelectedDate` and reset currently selected date in the picker. Currently if update `initialSelectedDate` the date selector is not updated to the date I needed.

this update fixed that issue.

I'm not sure if that's an intended behavior or if there's any other way to achieve the result I need.