### PR TITLE
Fixed bug where initialSelectedDate was not changing even after rebuilding widget

### DIFF
--- a/lib/date_picker_widget.dart
+++ b/lib/date_picker_widget.dart
@@ -144,6 +144,7 @@ class _DatePickerState extends State<DatePicker> {
 
   @override
   Widget build(BuildContext context) {
+    _currentDate = widget.initialSelectedDate;
     return Container(
       height: widget.height,
       child: ListView.builder(


### PR DESCRIPTION
I want to reinitialize the _currentDate after I changed initialSelectedDate in my app. So you can change initialSelectedDate programmatically even after your widget page initialized.