### PR TITLE
Compatibly with flutter 2.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.16.1
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Because every version of flutter_localizations from sdk depends on intl 0.17.0 and date_picker_timeline 1.2.1 depends on intl ^0.16.0, flutter_localizations from sdk is incompatible with date_picker_timeline 1.2.1.