### PR TITLE
Added didUpdateWidget. This function called whenever the widget configuration changes.

### DIFF
--- a/lib/date_picker_widget.dart
+++ b/lib/date_picker_widget.dart
@@ -128,6 +128,15 @@ class _DatePickerState extends State<DatePicker> {
     super.initState();
   }
 
+    @override
+  void didUpdateWidget(covariant DatePicker oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _currentDate = widget.initialSelectedDate;
+   if (widget.controller != null) {
+     widget.controller!.animateToSelection();
+   }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Container(


### PR DESCRIPTION
If the parent widget rebuilds , the framework will update the [widget] property of this [State] object to refer to the new widget and then call this method with the previous widget as an argument.

Override this method to respond when the [widget] changes.

The framework always calls [build] after calling [didUpdateWidget], which means setState not required in thi function.

I used this function update current date if it's change and animate to this date.