### PR TITLE
fix: use calendar-based DateTime construction to avoid DST drift

### DIFF
--- a/lib/date_picker_widget.dart
+++ b/lib/date_picker_widget.dart
@@ -110,6 +110,12 @@ class _DatePickerState extends State<DatePicker> {
   late final TextStyle deactivatedMonthStyle;
   late final TextStyle deactivatedDayStyle;
 
+  late final DateTime baseDate = DateTime(
+    widget.startDate.year,
+    widget.startDate.month,
+    widget.startDate.day,
+  );  
+
   @override
   void initState() {
     // Init the calendar locale
@@ -153,7 +159,11 @@ class _DatePickerState extends State<DatePicker> {
             // get the date object based on the index position
             // if widget.startDate is null then use the initialDateValue
             DateTime date;
-            DateTime _date = widget.startDate.add(Duration(days: index));
+            DateTime _date = DateTime(
+              baseDate.year,
+              baseDate.month,
+              baseDate.day + index,
+            );
             switch (widget.calendarType) {
               case CalendarType.persianDate:
                 date = PersianDate.toJalali(_date.year, _date.month, _date.day);


### PR DESCRIPTION
Using startDate.add(Duration(days: n)) caused the generated dates to shift by one hour during DST transitions (e.g., 2025-10-26 in Spain), resulting in duplicate or incorrect days. Replaced the increment logic with a component-based DateTime constructor to ensure consistent midnight dates regardless of timezone offset changes.